### PR TITLE
Add previewing

### DIFF
--- a/backend/app/api/s3_routes.py
+++ b/backend/app/api/s3_routes.py
@@ -7,7 +7,7 @@ import meilisearch
 from botocore.exceptions import ClientError
 from app.s3.search import iter_s3_objects, search_from_meili
 from app.schemas.s3_models import S3ObjectModel
-from app.s3.utils import parse_s3_uri, get_public_client
+from app.s3.utils import parse_s3_uri, get_public_client, generate_preview_url
 from app.s3.index_refresh import refresh_meili_index
 
 s3_router = APIRouter(prefix="/api/s3", tags=["s3"])
@@ -103,3 +103,11 @@ def download_file(s3_uri: str = Query(..., description="s3://bucket/key")):
                              headers={
                                  "Content-Disposition": f"attachment; filename={filename}"
                              })
+
+
+@s3_router.get("/preview")
+def s3_preview(bucket: str, key: str):
+    url = generate_preview_url(bucket, key)
+    if not url:
+        raise HTTPException(status_code=400, detail="Failed to generate URL")
+    return {"preview_url": url}

--- a/backend/app/s3/utils.py
+++ b/backend/app/s3/utils.py
@@ -14,3 +14,25 @@ def parse_s3_uri(uri: str) -> tuple[str, str]:
 def get_public_client(region: Optional[str] = None) -> S3Client:
     return boto3.client("s3", region_name=region, 
                         config=Config(signature_version=UNSIGNED))
+
+def generate_preview_url(bucket: str, key: str, expires_in=300):
+    try:
+        s3_client = boto3.client(
+            "s3", 
+            config=Config(signature_version='s3v4')
+        )
+        
+        url = s3_client.generate_presigned_url(
+            "get_object",
+            Params={
+                "Bucket": bucket,
+                "Key": key,
+            },
+            ExpiresIn=expires_in,
+        )
+        return url
+    except Exception as e:
+        # Ams credentials failed
+        print(f"Presigned URL failed: {e}")
+        # failsafe, try public
+        return f"https://{bucket}.s3.amazonaws.com/{key}"

--- a/frontend/src/lib/s3/S3ResultsTable.svelte
+++ b/frontend/src/lib/s3/S3ResultsTable.svelte
@@ -6,6 +6,43 @@
   export let items: S3ObjectModel[] = [];
   export let searchedYet: boolean = false;
   export let onDownload: (key: string, bucket: string) => void;
+
+  const PREVIEWABLE_EXTENSIONS = ['.pdf', '.png', '.jpg', '.jpeg', '.webp'];
+
+  let previewKey: string | null = null;
+  let previewUrl: string | null = null;
+
+async function handlePreview(key: string) {
+  // Extract ONLY the bucket name (in case s3Uri is s3://my-bucket/folder/)
+  const bucketName = s3Uri.replace(/^s3:\/\//, "").split('/')[0];
+
+  try {
+    const response = await fetch(
+      `/api/s3/preview?bucket=${encodeURIComponent(bucketName)}&key=${encodeURIComponent(key)}`
+    );
+
+    if (!response.ok) {
+      console.error("Preview failed", response.statusText);
+      previewUrl = null;
+      previewKey = null; 
+      return;
+    }
+
+    const data = await response.json();
+    previewUrl = data.preview_url;
+    previewKey = key; 
+  } catch (err) {
+    console.error("Preview failed", err);
+    previewUrl = null;
+    previewKey = null; 
+  }
+}
+
+function canPreview(key: string): boolean {
+    const lowerKey = key.toLowerCase();
+    return PREVIEWABLE_EXTENSIONS.some(ext => lowerKey.endsWith(ext));
+  }
+
 </script>
 
 {#if !searchedYet}
@@ -23,17 +60,26 @@
     <thead>
       <tr class="border-b bg-white">
         <th class="text-left p-2">Key</th>
-        <th class="text-left p-2">Size bytes</th>
+        <th class="text-left p-2">Size</th> 
         <th class="text-left p-2">Last modified</th>
         <th class="text-left p-2">Storage class</th>
         <th class="text-left p-2">Download</th>
+        <th class="text-left p-2">Preview</th>
       </tr>
     </thead>
     <tbody>
       {#each items as obj}
         <tr class="border-b odd:bg-gray-100">
           <td class="p-2 font-mono text-xs break-all">{obj.key}</td>
-          <td class="p-2">{obj.size}</td>
+          
+          <td class="p-2 whitespace-nowrap">
+            {#if obj.size < 1048576}
+              {(obj.size / 1024).toFixed(2)} KB
+            {:else}
+              {(obj.size / (1024 * 1024)).toFixed(2)} MB
+            {/if}
+          </td>
+
           <td class="p-2">{obj.last_modified ?? "unknown"}</td>
           <td class="p-2">{obj.storage_class ?? "STANDARD"}</td>
           <td class="p-2">
@@ -45,7 +91,71 @@
               <Download size={18} />
             </button>
           </td>
+
+          <td class="p-2">
+            {#if canPreview(obj.key)}
+              <button
+                on:click={() => handlePreview(obj.key)}
+                class="text-green-600 hover:text-green-800 font-bold"
+              >
+                Preview
+              </button>
+            {:else}
+              <button
+                disabled
+                class="text-red-400 cursor-not-allowed opacity-70 italic"
+                title="Cannot preview this file type"
+              >
+                No Preview
+              </button>
+            {/if}
+          </td>
         </tr>
+
+        {#if previewUrl && previewKey === obj.key}
+          <tr>
+            <td colspan="6" class="p-4 bg-gray-50 border-x border-b shadow-inner">
+              <div class="flex flex-col items-center justify-center w-full">
+                
+                {#if obj.key.endsWith(".pdf")}
+                  <iframe
+                    src={previewUrl}
+                    title="PDF Preview"
+                    class="w-full max-w-4xl h-[600px] border shadow-md bg-white"
+                  />
+                
+                {:else if obj.size > 52428800} 
+                  <div class="flex flex-col items-center p-8 border-2 border-dashed border-gray-300 rounded-lg bg-white shadow-sm text-center max-w-md">
+                    <p class="text-amber-600 font-bold text-lg mb-2">Massive File Notice</p>
+                    <p class="text-gray-600 mb-6">
+                      This file is <strong>{(obj.size / (1024 * 1024)).toFixed(1)} MB</strong>. 
+                      Loading it here might crash your browser.
+                    </p>
+                    <a href={previewUrl} target="_blank" rel="noopener noreferrer" class="bg-blue-600 text-white px-6 py-2 rounded-md">
+                      Open Full Resolution ↗
+                    </a>
+                  </div>
+
+                {:else}
+                  <div class="bg-white p-2 border shadow-lg rounded-sm">
+                    <img
+                      src={previewUrl}
+                      alt="Preview"
+                      class="max-w-full max-h-[600px] object-contain block mx-auto"
+                    />
+                  </div>
+                {/if}
+
+                <button 
+                  on:click={() => { previewUrl = null; previewKey = null; }}
+                  class="mt-4 text-xs text-gray-400 hover:text-red-500 uppercase tracking-widest font-bold"
+                >
+                  [ Close Preview ]
+                </button>
+              </div>
+            </td>
+          </tr>
+        {/if}
       {/each}
     </tbody>
   </table>


### PR DESCRIPTION
+ previewing functionality
+ changed to display better units (kbs, mbs, instead of just byte)
+ previewing allowed for pdf, png, jpg, jpeg, and .webp
+ previews larger than 50mb or  52428800 bits are opened in a new tab (easier on the browser to display just the image if its too big)